### PR TITLE
Accessibility: Add aria-label to icon buttons

### DIFF
--- a/reflect-metadata.js
+++ b/reflect-metadata.js
@@ -1,0 +1,10 @@
+// https://github.com/rbuckton/reflect-metadata
+require('../modules/esnext.reflect.define-metadata');
+require('../modules/esnext.reflect.delete-metadata');
+require('../modules/esnext.reflect.get-metadata');
+require('../modules/esnext.reflect.get-metadata-keys');
+require('../modules/esnext.reflect.get-own-metadata');
+require('../modules/esnext.reflect.get-own-metadata-keys');
+require('../modules/esnext.reflect.has-metadata');
+require('../modules/esnext.reflect.has-own-metadata');
+require('../modules/esnext.reflect.metadata');


### PR DESCRIPTION
Icon-only buttons currently lack accessible names, causing screen readers to announce them as generic 'button' and hindering navigation. Update Button/IconButton to accept and forward an aria-label prop, add unit/storybook tests, and audit existing icon-only usages to add appropriate labels.