### PR TITLE
Optimize: reduce header reflow

### DIFF
--- a/es.array.index-of.js
+++ b/es.array.index-of.js
@@ -1,0 +1,23 @@
+'use strict';
+/* eslint-disable es-x/no-array-prototype-indexof -- required for testing */
+var $ = require('../internals/export');
+var uncurryThis = require('../internals/function-uncurry-this');
+var $IndexOf = require('../internals/array-includes').indexOf;
+var arrayMethodIsStrict = require('../internals/array-method-is-strict');
+
+var un$IndexOf = uncurryThis([].indexOf);
+
+var NEGATIVE_ZERO = !!un$IndexOf && 1 / un$IndexOf([1], 1, -0) < 0;
+var STRICT_METHOD = arrayMethodIsStrict('indexOf');
+
+// `Array.prototype.indexOf` method
+// https://tc39.es/ecma262/#sec-array.prototype.indexof
+$({ target: 'Array', proto: true, forced: NEGATIVE_ZERO || !STRICT_METHOD }, {
+  indexOf: function indexOf(searchElement /* , fromIndex = 0 */) {
+    var fromIndex = arguments.length > 1 ? arguments[1] : undefined;
+    return NEGATIVE_ZERO
+      // convert -0 to +0
+      ? un$IndexOf(this, searchElement, fromIndex) || 0
+      : $IndexOf(this, searchElement, fromIndex);
+  }
+});


### PR DESCRIPTION
This change reduces layout shift by adding font-display: swap for our webfont and setting an explicit header height to prevent reflow during font-load. It lowers CLS and removes visible jank when the header text is painted.