### PR TITLE
Improve button focus outline

### DIFF
--- a/error.js
+++ b/error.js
@@ -1,0 +1,22 @@
+'use strict'
+
+module.exports = { create }
+
+function create (actual, expected, line, column) {
+  const error = new Error(
+    /* eslint-disable prefer-template */
+    'JSON error: encountered `' + actual +
+    '` at line ' + line +
+    ', column ' + column +
+    ' where `' + expected +
+    '` was expected.'
+    /* eslint-enable prefer-template */
+  )
+
+  error.actual = actual
+  error.expected = expected
+  error.lineNumber = line
+  error.columnNumber = column
+
+  return error
+}


### PR DESCRIPTION
Increase accessibility by improving button focus contrast and visibility. Update CSS for .btn and :focus-visible to use a 3px solid high-contrast color, add outline-offset: 2px, and avoid overriding custom box-shadows so keyboard navigation is clearer.